### PR TITLE
fix: SimpleApplication class doesn't have addOnTouchViewListener

### DIFF
--- a/sample/simple_application.py
+++ b/sample/simple_application.py
@@ -12,8 +12,11 @@ mutex = Lock()
 
 class SimpleApplication(AbsApp, InputEventListener, OnTouchEventListener, GestureListener):
 
-    def __init__(self, parameter_list):
+    def __init__(self):
         super().__init__(None)
+
+        # set counter to count up touch
+        self.counter = 0
 
         # connect to mui display
         self.display = Display()
@@ -32,7 +35,7 @@ class SimpleApplication(AbsApp, InputEventListener, OnTouchEventListener, Gestur
         text.setSize(0, 0, 100, 32) # set position and size (x, y, width, height)
         self.addView(text) # add view to this application
         self.setView(text, 'text') # set view with reference key. when you'd like to access this view, you can get this view via self.getView('key')
-        self.addOnTouchViewListener(self) # set callback method(onTouch()) to catch touch event. 
+        text.addOnTouchViewListener(self) # set callback method(onTouch()) to catch touch event. 
 
 
     def mainLoop(self):
@@ -74,7 +77,10 @@ class SimpleApplication(AbsApp, InputEventListener, OnTouchEventListener, Gestur
 
     def onTouch(self, view, e: MotionEvent):
         # handling touch events
-        pass
+        self.counter += 1
+        text = self.getView("text")
+        text.setText("touch %d" % self.counter)
+        self.updateUI()
 
     def onFling(self, e1: MotionEvent,  e2: MotionEvent, x, y):
         # handling swipe event


### PR DESCRIPTION
# Problem
sample/simple_application.py doesn't work because:
- SimpleApplication __init__ needs 1 parameter but the parameter is not given (line 87)
- SimpleApplication doesn't have addOnTouchViewListener.

# How I fixed
- remove "parameter_list" from __init__
- add event listener to a text part
- write count up sample to onTouch function